### PR TITLE
Migrate to multiple publisher accounts and version bumps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "aws_deploy-ap-southeast-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "blue"
   bootstrap_version = "${var.bootstrap_version}"
@@ -23,7 +23,7 @@ module "aws_deploy-ap-southeast-1" {
 }
 
 module "aws_deploy-eu-central-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "blue"
   bootstrap_version = "${var.bootstrap_version}"
@@ -45,11 +45,11 @@ module "aws_deploy-eu-central-1" {
     aws = "aws.eu-central-1"
   }
 
-  depends_on = ["${module.aws_deploy-ap-southeast-1.static_node_ips}"]
+  dependency = "${module.aws_deploy-ap-southeast-1.static_node_ips}"
 }
 
 module "aws_deploy-us-west-2" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "green"
   bootstrap_version = "${var.bootstrap_version}"
@@ -73,7 +73,7 @@ module "aws_deploy-us-west-2" {
 }
 
 module "aws_deploy-uat-eu-north-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "green"
   bootstrap_version = "${var.bootstrap_version}"
@@ -95,11 +95,11 @@ module "aws_deploy-uat-eu-north-1" {
     aws = "aws.eu-north-1"
   }
 
-  depends_on = ["${module.aws_deploy-us-west-2.static_node_ips}"]
+  dependency = "${module.aws_deploy-us-west-2.static_node_ips}"
 }
 
 module "aws_deploy-uat_mon-ap-southeast-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.1.1"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "blue"
   bootstrap_version = "${var.bootstrap_version}"
@@ -123,7 +123,7 @@ module "aws_deploy-uat_mon-ap-southeast-1" {
 }
 
 module "aws_deploy-uat_mon-eu-central-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.1.1"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "blue"
   bootstrap_version = "${var.bootstrap_version}"
@@ -147,7 +147,7 @@ module "aws_deploy-uat_mon-eu-central-1" {
 }
 
 module "aws_deploy-uat_mon-us-west-2" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.1.1"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "green"
   bootstrap_version = "${var.bootstrap_version}"
@@ -171,7 +171,7 @@ module "aws_deploy-uat_mon-us-west-2" {
 }
 
 module "aws_deploy-uat_mon-eu-north-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.1.1"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "green"
   bootstrap_version = "${var.bootstrap_version}"

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,9 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.6.1"
+  default = "v2.6.2"
 }
 
 variable "package" {
-  default = "https://releases.ops.aeternity.com/aeternity-3.3.0-ubuntu-x86_64.tar.gz"
+  default = "https://releases.ops.aeternity.com/aeternity-4.0.0-ubuntu-x86_64.tar.gz"
 }


### PR DESCRIPTION
This rely to the [v1.0](https://github.com/aeternity/terraform-aws-aenode-deploy/pull/12) branch to avoid rebuilding the network (destroying nodes)

in scope of https://www.pivotaltracker.com/story/show/165559131