### PR TITLE
Uat additional storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,8 +118,8 @@ module "aws_deploy-uat_mon-ap-southeast-1" {
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 0
-  spot_nodes   = 1
+  spot_nodes_min = 1
+  spot_nodes_max = 1
 
   spot_price    = "0.03"
   instance_type = "t3.medium"
@@ -145,8 +145,8 @@ module "aws_deploy-uat_mon-eu-central-1" {
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 0
-  spot_nodes   = 1
+  spot_nodes_min = 1
+  spot_nodes_max = 1
 
   spot_price    = "0.03"
   instance_type = "t3.medium"
@@ -172,8 +172,8 @@ module "aws_deploy-uat_mon-us-west-2" {
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 0
-  spot_nodes   = 1
+  spot_nodes_min = 1
+  spot_nodes_max = 1
 
   spot_price    = "0.03"
   instance_type = "t3.medium"
@@ -199,8 +199,8 @@ module "aws_deploy-uat_mon-eu-north-1" {
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 0
-  spot_nodes   = 1
+  spot_nodes_min = 1
+  spot_nodes_max = 1
 
   spot_price    = "0.03"
   instance_type = "t3.medium"

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,9 @@ module "aws_deploy-ap-southeast-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 1
   spot_nodes   = 14
@@ -13,8 +13,11 @@ module "aws_deploy-ap-southeast-1" {
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
+  additional_storage      = 1
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
@@ -26,45 +29,51 @@ module "aws_deploy-eu-central-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "blue"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 1
   spot_nodes   = 9
+
+  additional_storage      = 1
+  additional_storage_size = 30
 
   spot_price    = "0.125"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
     aws = "aws.eu-central-1"
   }
 
-  dependency = "${module.aws_deploy-ap-southeast-1.static_node_ips}"
+  dependency = module.aws_deploy-ap-southeast-1.static_node_ips
 }
 
 module "aws_deploy-us-west-2" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 1
   spot_nodes   = 14
+
+  additional_storage      = 1
+  additional_storage_size = 30
 
   spot_price    = "0.125"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
@@ -76,9 +85,9 @@ module "aws_deploy-uat-eu-north-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
   env               = "uat"
   color             = "green"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 1
   spot_nodes   = 9
@@ -87,24 +96,27 @@ module "aws_deploy-uat-eu-north-1" {
   instance_type = "m5.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
+  additional_storage      = 1
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
     aws = "aws.eu-north-1"
   }
 
-  dependency = "${module.aws_deploy-us-west-2.static_node_ips}"
+  dependency = module.aws_deploy-us-west-2.static_node_ips
 }
 
 module "aws_deploy-uat_mon-ap-southeast-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "blue"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 0
   spot_nodes   = 1
@@ -113,8 +125,11 @@ module "aws_deploy-uat_mon-ap-southeast-1" {
   instance_type = "t3.medium"
   ami_name      = "aeternity-ubuntu-16.04-v1559735157"
 
+  additional_storage      = true
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
@@ -126,9 +141,9 @@ module "aws_deploy-uat_mon-eu-central-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "blue"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 0
   spot_nodes   = 1
@@ -137,8 +152,11 @@ module "aws_deploy-uat_mon-eu-central-1" {
   instance_type = "t3.medium"
   ami_name      = "aeternity-ubuntu-16.04-v1559735157"
 
+  additional_storage      = true
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
@@ -150,9 +168,9 @@ module "aws_deploy-uat_mon-us-west-2" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "green"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 0
   spot_nodes   = 1
@@ -161,8 +179,11 @@ module "aws_deploy-uat_mon-us-west-2" {
   instance_type = "t3.medium"
   ami_name      = "aeternity-ubuntu-16.04-v1559735157"
 
+  additional_storage      = true
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {
@@ -174,9 +195,9 @@ module "aws_deploy-uat_mon-eu-north-1" {
   source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
   env               = "uat_mon"
   color             = "green"
-  bootstrap_version = "${var.bootstrap_version}"
+  bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
-  vault_addr        = "${var.vault_addr}"
+  vault_addr        = var.vault_addr
 
   static_nodes = 0
   spot_nodes   = 1
@@ -185,8 +206,11 @@ module "aws_deploy-uat_mon-eu-north-1" {
   instance_type = "t3.medium"
   ami_name      = "aeternity-ubuntu-16.04-v1559735157"
 
+  additional_storage      = true
+  additional_storage_size = 30
+
   aeternity = {
-    package = "${var.package}"
+    package = var.package
   }
 
   providers = {

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,9 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.6.2"
+  default = "v2.6.3"
 }
 
 variable "package" {
-  default = "https://releases.ops.aeternity.com/aeternity-4.0.0-ubuntu-x86_64.tar.gz"
+  default = "https://releases.ops.aeternity.com/aeternity-4.1.0-ubuntu-x86_64.tar.gz"
 }


### PR DESCRIPTION
- [x] Should be rebased / merged after #3 
- [x] and right after https://github.com/aeternity/infrastructure/pull/409 (which is asumed to be tagged v2.6.3)

This will enable additional storage to all nodes, but the seed static nodes (that use v1.2.0) will not be configured to store their db until redeployed. Terraform should apply the changes inplace. 
Spot nodes will be rebuilt.

Uat monitoring nodes most likely will be destroyed first, which will trigger full deploy.