### PR TITLE
Migrate UAT infrastructure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,22 @@
 module "aws_deploy-ap-southeast-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat"
   color             = "blue"
   bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 1
-  spot_nodes   = 14
+  static_nodes   = 1
+  spot_nodes_min = 9
+  spot_nodes_max = 9
 
-  spot_price    = "0.125"
+  additional_storage      = true
+  additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
+
+  spot_price    = "0.07"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
-
-  additional_storage      = 1
-  additional_storage_size = 30
 
   aeternity = {
     package = var.package
@@ -26,20 +28,22 @@ module "aws_deploy-ap-southeast-1" {
 }
 
 module "aws_deploy-eu-central-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat"
   color             = "blue"
   bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 1
-  spot_nodes   = 9
+  static_nodes   = 1
+  spot_nodes_min = 9
+  spot_nodes_max = 9
 
-  additional_storage      = 1
+  additional_storage      = true
   additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
 
-  spot_price    = "0.125"
+  spot_price    = "0.07"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
@@ -50,26 +54,26 @@ module "aws_deploy-eu-central-1" {
   providers = {
     aws = "aws.eu-central-1"
   }
-
-  dependency = module.aws_deploy-ap-southeast-1.static_node_ips
 }
 
 module "aws_deploy-us-west-2" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat"
   color             = "green"
   bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 1
-  spot_nodes   = 14
+  static_nodes   = 1
+  spot_nodes_min = 9
+  spot_nodes_max = 9
 
-  additional_storage      = 1
+  additional_storage      = true
   additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
 
-  spot_price    = "0.125"
-  instance_type = "m4.large"
+  spot_price    = "0.07"
+  instance_type = "m5.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
@@ -82,22 +86,24 @@ module "aws_deploy-us-west-2" {
 }
 
 module "aws_deploy-uat-eu-north-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v1.2.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat"
   color             = "green"
   bootstrap_version = var.bootstrap_version
   vault_role        = "ae-node"
   vault_addr        = var.vault_addr
 
-  static_nodes = 1
-  spot_nodes   = 9
+  static_nodes   = 1
+  spot_nodes_min = 9
+  spot_nodes_max = 9
+
+  additional_storage      = true
+  additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
 
   spot_price    = "0.07"
   instance_type = "m5.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
-
-  additional_storage      = 1
-  additional_storage_size = 30
 
   aeternity = {
     package = var.package
@@ -106,12 +112,10 @@ module "aws_deploy-uat-eu-north-1" {
   providers = {
     aws = "aws.eu-north-1"
   }
-
-  dependency = module.aws_deploy-us-west-2.static_node_ips
 }
 
 module "aws_deploy-uat_mon-ap-southeast-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat_mon"
   color             = "blue"
   bootstrap_version = var.bootstrap_version
@@ -121,12 +125,12 @@ module "aws_deploy-uat_mon-ap-southeast-1" {
   spot_nodes_min = 1
   spot_nodes_max = 1
 
-  spot_price    = "0.03"
-  instance_type = "t3.medium"
-  ami_name      = "aeternity-ubuntu-16.04-v1559735157"
-
   additional_storage      = true
   additional_storage_size = 30
+
+  spot_price    = "0.07"
+  instance_type = "t3.medium"
+  ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
     package = var.package
@@ -138,7 +142,7 @@ module "aws_deploy-uat_mon-ap-southeast-1" {
 }
 
 module "aws_deploy-uat_mon-eu-central-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat_mon"
   color             = "blue"
   bootstrap_version = var.bootstrap_version
@@ -148,12 +152,13 @@ module "aws_deploy-uat_mon-eu-central-1" {
   spot_nodes_min = 1
   spot_nodes_max = 1
 
-  spot_price    = "0.03"
-  instance_type = "t3.medium"
-  ami_name      = "aeternity-ubuntu-16.04-v1559735157"
-
   additional_storage      = true
   additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
+
+  spot_price    = "0.07"
+  instance_type = "t3.medium"
+  ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
     package = var.package
@@ -165,7 +170,7 @@ module "aws_deploy-uat_mon-eu-central-1" {
 }
 
 module "aws_deploy-uat_mon-us-west-2" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat_mon"
   color             = "green"
   bootstrap_version = var.bootstrap_version
@@ -175,12 +180,13 @@ module "aws_deploy-uat_mon-us-west-2" {
   spot_nodes_min = 1
   spot_nodes_max = 1
 
-  spot_price    = "0.03"
-  instance_type = "t3.medium"
-  ami_name      = "aeternity-ubuntu-16.04-v1559735157"
-
   additional_storage      = true
   additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
+
+  spot_price    = "0.07"
+  instance_type = "t3.medium"
+  ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
     package = var.package
@@ -192,7 +198,7 @@ module "aws_deploy-uat_mon-us-west-2" {
 }
 
 module "aws_deploy-uat_mon-eu-north-1" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.0.0"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=v2.1.0"
   env               = "uat_mon"
   color             = "green"
   bootstrap_version = var.bootstrap_version
@@ -202,12 +208,13 @@ module "aws_deploy-uat_mon-eu-north-1" {
   spot_nodes_min = 1
   spot_nodes_max = 1
 
-  spot_price    = "0.03"
-  instance_type = "t3.medium"
-  ami_name      = "aeternity-ubuntu-16.04-v1559735157"
-
   additional_storage      = true
   additional_storage_size = 30
+  snapshot_filename       = "mnesia_uat_v-1_latest.gz"
+
+  spot_price    = "0.07"
+  instance_type = "t3.medium"
+  ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
     package = var.package

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.6.4"
+  default = "v2.6.5"
 }
 
 variable "package" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "vault_addr" {
 }
 
 variable "bootstrap_version" {
-  default = "v2.6.3"
+  default = "v2.6.4"
 }
 
 variable "package" {


### PR DESCRIPTION
1. Bump boostrap version
1. Bump aenode-deploy version
1. Add additional storage and put database there
1. use m5 or m4 where appropriate. Note: api-southeast-1 and eu-central-1 support m5.* but seems there is not enough capacity currently and it kills the spot instances too often to make it unusable, so we use m4 there.

Notes:
- seed/peer node changes are already manually applied, so no changes should apply there after merge
- use t3.medium for monitoring nodes
- monitor nodes will not boostrap until [this fix](https://github.com/aeternity/infrastructure/pull/413) is merged

Changes are already applied