### PR TITLE
Bump to 5.0.0-rc6

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,14 +12,14 @@ module "aws_deploy-ap-southeast-1" {
 
   additional_storage      = true
   additional_storage_size = 30
-  snapshot_filename       = "mnesia_uat_v-1_54.255.167.41_uat_db_backup_1569308314.tgz"
+  snapshot_filename       = "mnesia_uat_v-1_latest.tgz"
 
   spot_price    = "0.07"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
-    package = "https://releases.aeternity.io/aeternity-5.0.0-rc.6-ubuntu-x86_64.tar.gz"
+    package = var.package
   }
 
   providers = {
@@ -41,14 +41,14 @@ module "aws_deploy-eu-central-1" {
 
   additional_storage      = true
   additional_storage_size = 30
-  snapshot_filename       = "mnesia_uat_v-1_54.255.167.41_uat_db_backup_1569308314.tgz"
+  snapshot_filename       = "mnesia_uat_v-1_latest.tgz"
 
   spot_price    = "0.07"
   instance_type = "m4.large"
   ami_name      = "aeternity-ubuntu-16.04-v1549009934"
 
   aeternity = {
-    package = "https://releases.aeternity.io/aeternity-5.0.0-rc.6-ubuntu-x86_64.tar.gz"
+    package = var.package
   }
 
   providers = {

--- a/variables.tf
+++ b/variables.tf
@@ -7,5 +7,5 @@ variable "bootstrap_version" {
 }
 
 variable "package" {
-  default = "https://releases.aeternity.io/aeternity-5.0.0-rc.5-ubuntu-x86_64.tar.gz"
+  default = "https://releases.aeternity.io/aeternity-5.0.0-rc.6-ubuntu-x86_64.tar.gz"
 }


### PR DESCRIPTION
Latest DB snapshot is created from a synced by rc6, so we can revert it as default for the rest of the nodes.

Note: Already applied.

Actual static node db migration is manual.